### PR TITLE
Add support for columns as the primary divider

### DIFF
--- a/lib/template/run.osascript
+++ b/lib/template/run.osascript
@@ -9,13 +9,13 @@ tell application "iTerm"
       -- Create a new session.
       [session]
 
-      -- Create rows.
-      [rows]
+      -- Create primary divider (rows or columns).
+      [primary]
 
       -- Sleep for a bit while we catch up.
       [sleep]
 
-      -- Create panes within each row.
+      -- Create panes within each primary divider.
       [panes]
 
       -- Terminate first or last session, which are unused.

--- a/lib/termrc/builder.rb
+++ b/lib/termrc/builder.rb
@@ -17,6 +17,7 @@ module Termrc
       @root       = yml['root']
       @commands   = yml['commands']
       @layout     = yml['layout']
+      @columns    = yml['columns'] || false
       @cmd_index  = 1
     end
 
@@ -57,7 +58,7 @@ module Termrc
         t = t.gsub("[terminate_unused]",  terminate_session)
       end
 
-      t = t.gsub("[rows]",      rows(layout_array))
+      t = t.gsub("[primary]",   primary(layout_array))
       t = t.gsub("[sleep]",     rest)
       t = t.gsub("[panes]",     panes(layout_array))
       t = t.gsub("[commands]",  commands(layout_array))
@@ -71,8 +72,8 @@ module Termrc
       file
     end
 
-    def rows(layout_array)
-      Array.new( row_count(layout_array), new_row ).join("\n")
+    def primary(layout_array)
+      Array.new( primary_count(layout_array), @columns ? new_column : new_row ).join("\n")
     end
 
     def panes(layout_array)
@@ -80,7 +81,7 @@ module Termrc
       cmd =   next_pane     # back to the top
 
       layout_array.each do |cmds|
-        cmd << Array.new( cmds.length - 1, new_column ).join("\n")
+        cmd << Array.new( cmds.length - 1, @columns ? new_row : new_column ).join("\n")
         cmd << next_pane
         cmd << "\n"
       end
@@ -106,7 +107,7 @@ module Termrc
       cmd
     end
 
-    def row_count(layout_array)
+    def primary_count(layout_array)
       layout_array.length
     end
 


### PR DESCRIPTION
Currently, rows are the primary divider, so you cannot have a setup where you have two panes on the left hand side and a single pane on the right hand side.  This change supports using columns as the primary divider so that this can be done.

The change is backwards compatible and configurable.
