### PR TITLE
add support for the fish shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 tmp/
 node_modules/
+.idea

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ A `Termfile` file is a YAML file which requires two keys: `commands` and a `layo
 
 You can supply an optional key, `root`, which indicates the root directory you'd like each command to be run inside of. Have a look at [this project's Termfile](https://github.com/briangonzalez/termrc/blob/master/Termfile.test) for an example.
 
+If you use the [fish shell](https://github.com/fish-shell/fish-shell/) you need to specify that.
+
+```
+shell:
+  fish
+```
+
 You can also supply a `layout_type` value, either `row` or `column`, which denotes whether to use rows or columns as the means for splitting the window. This defaults to `layout_type: row`.
 
 **Tabs**

--- a/lib/termrc/builder.rb
+++ b/lib/termrc/builder.rb
@@ -14,9 +14,10 @@ module Termrc
     attr_accessor :commands
 
     def initialize(yml)
-      @root       = yml['root'] || File.dirname( File.expand_path('./Termfile') )
-      @commands   = yml['commands']
-      @windows    = yml['windows'] || []
+      @continueIfSuccess = if yml['shell'].eql? 'fish' then "; and " else " && " end
+      @root              = yml['root'] || File.dirname( File.expand_path('./Termfile') )
+      @commands          = yml['commands']
+      @windows           = yml['windows'] || []
 
       #support traditional format not using multiple windows
       if yml['layout']
@@ -168,7 +169,7 @@ module Termrc
     def execute_command(item, command, name)
       command = command.gsub('"', '\\"')
       command = command.gsub("'", "\\'")
-      command = "cd #{@root} && " + command if @root
+      command = "cd #{@root} #{@continueIfSuccess} " + command if @root
       <<-EOH
         tell item #{item} of sessions to set name to "#{name}" \n
         tell item #{item} of sessions to write text \"#{command}\" \n


### PR DESCRIPTION
I have iTerm2 setup to use the fish shell.  It doesn't like the && operator from bash.  I added an optional configuration so that a user could specify the shell in their TermFile.  If they don't specify the shell we just use the && operator as before.